### PR TITLE
Update style to prevent horizontal scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,6 +171,7 @@ a:hover {
 .stTabs [data-baseweb="tab-panel"] {
     background-color: #1e1e1e;
     padding: 15px;
+    box-sizing: border-box;
     border-radius: 0 0 10px 10px;
     color: #e0e0e0;
     border-left: 1px solid #333;
@@ -198,6 +199,7 @@ a:hover {
 .stDataFrame, .stTable { /* Applicato anche a st.table se usato */
     border: 1px solid #333;
     border-radius: 6px; /* Angoli arrotondati */
+    box-sizing: border-box;
     overflow: hidden; /* Per far rispettare il border-radius ai figli */
 }
 .stDataFrame th, .stTable th {


### PR DESCRIPTION
## Summary
- fix layout jump when switching tabs by applying `box-sizing: border-box` to tab panels
- ensure DataFrame/Table containers use `box-sizing: border-box`

## Testing
- `pip install -r requirements.txt`
- `streamlit run app.py` *(fails to fetch external IP but server starts)*


------
https://chatgpt.com/codex/tasks/task_e_68555e2adf448320b69f563682112248