### PR TITLE
Fix page width jump

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,10 @@ st.markdown("""
         background-color: #121212;
         color: #e0e0e0;
     }
+
+    html, body {
+        overflow-y: scroll;
+    }
     
     /* Sidebar dark */
     [data-testid="stSidebar"] {
@@ -149,6 +153,7 @@ st.markdown("""
     .stTabs [data-baseweb="tab-panel"] {
         background-color: #1e1e1e;
         padding: 15px;
+        box-sizing: border-box;
         border-radius: 0 0 10px 10px;
         color: #e0e0e0;
         border-left: 1px solid #333;
@@ -170,8 +175,9 @@ st.markdown("""
     }
     
     /* DataFrames e tabelle */
-    .stDataFrame {
+    .stDataFrame, .stTable {
         border: 1px solid #333;
+        box-sizing: border-box;
     }
     .stDataFrame th {
         background-color: #252525 !important;

--- a/style.css
+++ b/style.css
@@ -4,6 +4,10 @@
     color: #e0e0e0;
 }
 
+html, body {
+    overflow-y: scroll;
+}
+
 /* Sidebar dark */
 [data-testid="stSidebar"] {
     background-color: #1a1a1a;
@@ -171,6 +175,7 @@ a:hover {
 .stTabs [data-baseweb="tab-panel"] {
     background-color: #1e1e1e;
     padding: 15px;
+    box-sizing: border-box;
     border-radius: 0 0 10px 10px;
     color: #e0e0e0;
     border-left: 1px solid #333;
@@ -198,6 +203,7 @@ a:hover {
 .stDataFrame, .stTable { /* Applicato anche a st.table se usato */
     border: 1px solid #333;
     border-radius: 6px; /* Angoli arrotondati */
+    box-sizing: border-box;
     overflow: hidden; /* Per far rispettare il border-radius ai figli */
 }
 .stDataFrame th, .stTable th {


### PR DESCRIPTION
## Summary
- keep vertical scrollbar visible to avoid layout shift
- confirm box-sizing applied for tabs and data tables
- embed same fixes in inline CSS

## Testing
- `pip install -r requirements.txt`
- `streamlit run app.py & sleep 5; pkill streamlit` *(fails to fetch external IP but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_68555e2adf448320b69f563682112248