### PR TITLE
Revert style changes breaking layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,7 +171,6 @@ a:hover {
 .stTabs [data-baseweb="tab-panel"] {
     background-color: #1e1e1e;
     padding: 15px;
-    box-sizing: border-box;
     border-radius: 0 0 10px 10px;
     color: #e0e0e0;
     border-left: 1px solid #333;
@@ -199,7 +198,6 @@ a:hover {
 .stDataFrame, .stTable { /* Applicato anche a st.table se usato */
     border: 1px solid #333;
     border-radius: 6px; /* Angoli arrotondati */
-    box-sizing: border-box;
     overflow: hidden; /* Per far rispettare il border-radius ai figli */
 }
 .stDataFrame th, .stTable th {


### PR DESCRIPTION
## Summary
- revert style commit that modified tab and table box sizing

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `streamlit run app.py` *(fails: Did not auto detect external IP)*

------
https://chatgpt.com/codex/tasks/task_e_685d52d48bbc83209396acd1f161e2fd