### PR TITLE
Fix VAT discount logic and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,22 @@ These headers must be present (with `(base)` or `(comp)` suffixes after upload) 
 - **Shipping & VAT Handling** – calculate net margins including shipping costs and market‑specific VAT rates.
 - **Interactive Dashboard** – visualize scores, margins and volume with histograms and scatter plots; save/load parameter "recipes" for repeated analyses.
 
+
+## VAT and Discount Logic
+
+Locale strings from the CSV files are normalized to a two letter country code (e.g. `Amazon.de` or `de-DE` become `DE`). `GB` is converted to `UK` so that the correct VAT rate is applied automatically.
+
+For purchases from foreign markets the discount is calculated on the VAT excluded price:
+
+```
+Net = Price / (1 + VAT) * (1 - Discount)
+```
+
+When buying in Italy the discount is first computed on the gross price and then subtracted from the VAT excluded price:
+
+```
+Net = Price / (1 + VAT) - Price * Discount
+```
+
+The dashboard chooses the proper VAT rate for each row and displays both origin and comparison market VAT percentages.
+

--- a/tests/test_purchase_price.py
+++ b/tests/test_purchase_price.py
@@ -1,0 +1,54 @@
+import ast
+import math
+import re
+import types
+
+# Minimal stub for pandas.isna used in app.py
+class _PandasStub(types.SimpleNamespace):
+    @staticmethod
+    def isna(value):
+        return isinstance(value, float) and math.isnan(value)
+
+pd = _PandasStub()
+
+
+def load_functions():
+    with open('app.py', 'r') as f:
+        source = f.read()
+    module = ast.parse(source)
+    env = {'re': re, 'pd': pd, 'math': math}
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == 'VAT_RATES':
+                    exec(compile(ast.Module([node], []), 'app.py', 'exec'), env)
+        elif isinstance(node, ast.FunctionDef) and node.name in {'normalize_locale', 'calc_final_purchase_price'}:
+            exec(compile(ast.Module([node], []), 'app.py', 'exec'), env)
+    return env['VAT_RATES'], env['normalize_locale'], env['calc_final_purchase_price']
+
+
+VAT_RATES, normalize_locale, calc_final_purchase_price = load_functions()
+
+
+def test_purchase_price_de():
+    row = {"Price_Base": 100, "Locale (base)": "DE"}
+    expected = 100 / (1 + 0.19) * (1 - 0.21)
+    assert math.isclose(calc_final_purchase_price(row, 0.21), expected, rel_tol=1e-6)
+
+
+def test_purchase_price_it():
+    row = {"Price_Base": 100, "Locale (base)": "IT"}
+    expected = 100 / (1 + 0.22) - 100 * 0.21
+    assert math.isclose(calc_final_purchase_price(row, 0.21), expected, rel_tol=1e-6)
+
+
+def test_locale_variants():
+    for variant in ["Amazon.de", "de-DE"]:
+        row = {"Price_Base": 100, "Locale (base)": variant}
+        expected = 100 / (1 + 0.19) * (1 - 0.21)
+        assert math.isclose(calc_final_purchase_price(row, 0.21), expected, rel_tol=1e-6)
+    for variant in ["Amazon.it", "it_IT"]:
+        row = {"Price_Base": 100, "Locale (base)": variant}
+        expected = 100 / (1 + 0.22) - 100 * 0.21
+        assert math.isclose(calc_final_purchase_price(row, 0.21), expected, rel_tol=1e-6)
+


### PR DESCRIPTION
## Summary
- normalize locale strings when applying VAT
- adjust purchase price formula for Italian vs foreign markets
- show normalized VAT rates in results
- document VAT calculation logic
- add regression tests for purchase price calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a0cbe9e483209349c20803cb14da