### PR TITLE
Remove secrets file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Local Streamlit secrets
+.streamlit/secrets.toml

--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,2 +1,0 @@
-API_KEY = "1nf5mcc4mb9li5hc2l9bnuo2oscq0io4f7h26vfeekb9fccr6e9q6hve5aqcbca4"
-PASSWORD = "1234"  # Sostituisci con una password a tua scelta

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ After installing dependencies, start the dashboard with:
 streamlit run app.py
 ```
 
+## Configuration
+
+Provide your Keepa API key and optional password using environment variables or a local `secrets.toml` file. When using environment variables set `API_KEY` (and `PASSWORD` if needed) before running Streamlit:
+
+```bash
+export API_KEY="your_keepa_key"
+export PASSWORD="your_password"
+```
+
+Alternatively create a `.streamlit/secrets.toml` file with the same fields. This file is ignored by Git and can be passed to Streamlit automatically when placed in the project directory:
+
+```toml
+API_KEY = "your_keepa_key"
+PASSWORD = "your_password"
+```
+
+
 ## Keepa Export Files
 
 The application expects Keepa CSV/XLSX exports for both the origin marketplace and the comparison marketplaces. Essential headers include:


### PR DESCRIPTION
## Summary
- delete `.streamlit/secrets.toml`
- ignore user secrets file
- document providing API key via env vars or custom `secrets.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878ef67f034832096d35bd0d27f4140