### PR TITLE
Fix dark theme path handling

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import streamlit as st
 
 
 def apply_dark_theme():
     """Inject the custom dark theme CSS used by the dashboard."""
-    st.markdown(
-        "<style>\n" + (
-            open("style.css", "r", encoding="utf-8").read() if st._is_running_with_streamlit else ""
-        ) + "\n</style>",
-        unsafe_allow_html=True,
-    )
+    css = ""
+    if st.runtime.exists():
+        try:
+            css = Path(__file__).with_name("style.css").read_text(encoding="utf-8")
+        except FileNotFoundError:
+            css = ""
+    st.markdown("<style>\n" + css + "\n</style>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- support running with streamlit runtime API
- load `style.css` using `Path` and ignore missing file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ffd3a5808320a10d9f0212adda0f