### PR TITLE
Add fullscreen view for results grid

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,10 @@ if "recipes" not in st.session_state:
 if "filtered_data" not in st.session_state:
     st.session_state["filtered_data"] = None
 
+# State for fullscreen grid view
+if "grid_fullscreen" not in st.session_state:
+    st.session_state["grid_fullscreen"] = False
+
 st.markdown(
     '<h1 class="main-header">📊 Amazon Market Analyzer - Arbitraggio Multi-Mercato</h1>',
     unsafe_allow_html=True,
@@ -943,6 +947,20 @@ if avvia:
                 go.configure_default_column(sortable=True, filter=True)
                 go.configure_grid_options(enableRangeSelection=True)
                 go = go.build()
+
+                container_cls = "fullscreen" if st.session_state.get("grid_fullscreen") else ""
+                st.markdown(
+                    f'<div id="results_grid_container" class="{container_cls}">',
+                    unsafe_allow_html=True,
+                )
+
+                if st.session_state.get("grid_fullscreen"):
+                    if st.button("Chiudi", key="close_grid_fullscreen"):
+                        st.session_state["grid_fullscreen"] = False
+                else:
+                    if st.button("Schermo intero", key="open_grid_fullscreen"):
+                        st.session_state["grid_fullscreen"] = True
+
                 AgGrid(
                     filtered_df[display_cols],
                     gridOptions=go,
@@ -952,6 +970,7 @@ if avvia:
                     key="results_grid",
                     enable_enterprise_modules=True,
                 )
+                st.markdown("</div>", unsafe_allow_html=True)
 
                 # Esportazione dati
                 csv_data = filtered_df.to_csv(index=False, sep=";").encode("utf-8")

--- a/style.css
+++ b/style.css
@@ -392,3 +392,15 @@ hr {
 [data-testid="stNotification"] a { /* Link dentro le notifiche */
     color: #0d6efd !important;
 }
+
+/* Container fullscreen for result grid */
+#results_grid_container.fullscreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 9999;
+    overflow: auto;
+    background-color: #121212;
+}


### PR DESCRIPTION
## Summary
- add session_state flag for fullscreen grid
- wrap results grid in a container that can be fullscreen
- toggle fullscreen with "Schermo intero" and "Chiudi" buttons
- add styles for fullscreen grid container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6a0f11b48320b6244565e74a963a