### PR TITLE
Add cross-market ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ PASSWORD = "your_password"
 
 ## Keepa Export Files
 
-The application expects Keepa CSV/XLSX exports for both the origin marketplace and the comparison marketplaces. Essential headers include:
+The application expects Keepa CSV/XLSX exports for both the origin marketplace and the comparison marketplaces. Multiple comparison files can be uploaded at once and will be merged automatically. Essential headers include:
 
 - `ASIN`
 - `Title`
@@ -51,6 +51,7 @@ These headers must be present (with `(base)` or `(comp)` suffixes after upload) 
 - **Advanced Filters** – limit results by sales rank, offer count, price range and minimum margins.
 - **Shipping & VAT Handling** – calculate net margins including shipping costs and market‑specific VAT rates.
 - **Interactive Dashboard** – visualize scores, margins and volume with histograms and scatter plots; save/load parameter "recipes" for repeated analyses.
+- **Cross-market Ranking** – upload multiple comparison lists and view a consolidated table showing the best marketplace and score for each ASIN.
 
 
 ## VAT and Discount Logic

--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ from score import (
     format_trend,
     classify_opportunity,
     compute_scores,
+    aggregate_opportunities,
 )
 from utils import load_preset, save_preset
 from ui import apply_dark_theme
@@ -79,6 +80,8 @@ if "recipes" not in st.session_state:
 # Inizializzazione dei dati filtrati per la sessione
 if "filtered_data" not in st.session_state:
     st.session_state["filtered_data"] = None
+if "ranked_data" not in st.session_state:
+    st.session_state["ranked_data"] = None
 
 # State for fullscreen grid view
 if "grid_fullscreen" not in st.session_state:
@@ -89,8 +92,13 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-tab_main1, tab_main2, tab_main3 = st.tabs(
-    ["📋 ASIN Caricati", "📊 Analisi Opportunità", "📎 Risultati Dettagliati"]
+tab_main1, tab_main2, tab_main3, tab_rank = st.tabs(
+    [
+        "📋 ASIN Caricati",
+        "📊 Analisi Opportunità",
+        "📎 Risultati Dettagliati",
+        "🏆 Classifica prodotti",
+    ]
 )
 
 #################################
@@ -658,8 +666,12 @@ if avvia:
         if col in df_finale.columns:
             df_finale[col] = df_finale[col].round(2)
 
+    # Classifica cross-country per ASIN
+    df_ranked = aggregate_opportunities(df_finale)
+
     # Salviamo i dati nella sessione per i filtri interattivi
     st.session_state["filtered_data"] = df_finale
+    st.session_state["ranked_data"] = df_ranked
 
     #################################
     # Dashboard Interattiva
@@ -1008,6 +1020,17 @@ if avvia:
             st.info(
                 "👈 Clicca su 'Calcola Opportunity Score' nella barra laterale per visualizzare i risultati."
             )
+
+    # Classifica prodotti per ASIN
+    with tab_rank:
+        ranked = st.session_state.get("ranked_data")
+        if ranked is not None and not ranked.empty:
+            st.markdown('<div class="result-container">', unsafe_allow_html=True)
+            st.subheader("🏆 Classifica prodotti")
+            st.dataframe(ranked, use_container_width=True)
+            st.markdown("</div>", unsafe_allow_html=True)
+        else:
+            st.info("👈 Calcola le opportunità per vedere la classifica.")
 
 # Aggiunta dell'help
 with st.expander("ℹ️ Come funziona l'Opportunity Score"):

--- a/score.py
+++ b/score.py
@@ -118,3 +118,23 @@ def compute_scores(df: pd.DataFrame, weights: Dict[str, float]) -> pd.DataFrame:
     score = sum(weights.get(k, 1.0) * subs[k] for k in subs)
     df["final_score"] = _minmax(score) * 100
     return df
+
+
+def aggregate_opportunities(df: pd.DataFrame) -> pd.DataFrame:
+    """Return one row per ASIN with the best market and score."""
+    if df is None or df.empty or "ASIN" not in df.columns:
+        return pd.DataFrame(columns=["ASIN", "Best_Market", "Opportunity_Score"])
+
+    if "Opportunity_Score" not in df.columns:
+        return pd.DataFrame(columns=["ASIN", "Best_Market", "Opportunity_Score"])
+
+    idx = df.groupby("ASIN") ["Opportunity_Score"].idxmax()
+    best = df.loc[idx].copy()
+    best = best.rename(columns={"Locale (comp)": "Best_Market"})
+
+    cols = ["ASIN"]
+    if "Title (base)" in best.columns:
+        cols.append("Title (base)")
+    cols += ["Best_Market", "Opportunity_Score"]
+
+    return best[cols].sort_values("Opportunity_Score", ascending=False).reset_index(drop=True)

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -5,7 +5,14 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from loaders import load_keepa
 import pandas as pd
-from score import margin_score, demand_score, competition_score, volatility_score, risk_score
+from score import (
+    margin_score,
+    demand_score,
+    competition_score,
+    volatility_score,
+    risk_score,
+    aggregate_opportunities,
+)
 
 
 def test_subscores_range():
@@ -24,3 +31,18 @@ def test_subscores_range():
     for func in [margin_score, demand_score, competition_score, volatility_score, risk_score]:
         scores = func(df)
         assert ((0.0 <= scores) & (scores <= 1.0)).all()
+
+
+def test_aggregate_opportunities():
+    df = pd.DataFrame(
+        {
+            "ASIN": ["A1", "A1", "A2"],
+            "Opportunity_Score": [10, 20, 15],
+            "Locale (comp)": ["DE", "FR", "IT"],
+        }
+    )
+    agg = aggregate_opportunities(df)
+    assert len(agg) == 2
+    a1 = agg[agg["ASIN"] == "A1"].iloc[0]
+    assert a1["Opportunity_Score"] == 20
+    assert a1["Best_Market"] == "FR"


### PR DESCRIPTION
## Summary
- compute best market per ASIN with `aggregate_opportunities`
- show cross-country ranking in new **Classifica prodotti** tab
- test aggregation logic
- update README about multiple comparison files and new ranking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4d3e8fe083208f1e8eff4bb3e5b4