### PR TITLE
Fix missing locale columns in historic deal computation

### DIFF
--- a/app.py
+++ b/app.py
@@ -254,7 +254,11 @@ def compute_historic_deals(df: pd.DataFrame) -> pd.DataFrame:
         ),
         axis=1,
     )
-
+    if "Locale" not in work.columns:
+        work["Locale"] = (
+            work.get("Locale (comp)", pd.Series("", index=work.index)).fillna("").astype(str)
+            + work.get("Locale (base)", pd.Series("", index=work.index)).fillna("").astype(str)
+        )
     work["VAT"] = work["Locale"].apply(get_vat_for_locale)
     work["NetSale"] = work["PriceNowGrossAfterDisc"] / (1.0 + work["VAT"])
 


### PR DESCRIPTION
## Summary
- Guard historic deal computations by constructing a `Locale` column from `Locale (comp)` and `Locale (base)` when missing

## Testing
- `pytest -q`
- Verify `compute_historic_deals` works without locale columns

------
https://chatgpt.com/codex/tasks/task_e_6896004c50d08320a0f4a5e116364111