### PR TITLE
Persist full dataset for historic deals tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -1219,6 +1219,9 @@ if avvia:
     # Ordiniamo i risultati per Opportunity Score decrescente
     df_merged = df_merged.sort_values("Opportunity_Score", ascending=False)
 
+    # Salva il dataset completo nella sessione per utilizzi futuri
+    st.session_state["full_data"] = df_merged
+
     # Selezione delle colonne finali da visualizzare
     cols_final = [c for c in DISPLAY_COLS_ORDER if c in df_merged.columns]
     df_finale = df_merged[cols_final].copy()
@@ -1308,7 +1311,7 @@ with st.expander("ℹ️ Come funziona l'Opportunity Score"):
     )
 
 # Tab Affari Storici
-df_final = st.session_state.get("filtered_data")
+df_final = st.session_state.get("full_data")
 
 with tab_deals:
     st.subheader("Affari Storici")


### PR DESCRIPTION
## Summary
- Save merged dataset as `full_data` in session state alongside filtered results
- Use the full dataset for the Historic Deals tab to access all Keepa metrics

## Testing
- `pytest -q`
- Manual run of `compute_historic_deals` confirms presence of key columns and non-empty output


------
https://chatgpt.com/codex/tasks/task_e_6896362afc1c8320820d2f2efdaca2b2