### PR TITLE
Add configurable cost model

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ from score import (
 )
 from utils import load_preset, save_preset, hash_file
 from ui import apply_dark_theme
+from costs import compute_costs
 
 
 @st.cache_data(show_spinner=False)
@@ -84,6 +85,13 @@ DISPLAY_COLS_ORDER = [
     "Package: Dimension (cm³) (base)",
     "IVA_Origine",
     "IVA_Confronto",
+    "sale_price_used",
+    "referral_pct",
+    "fba_fee",
+    "billable_kg",
+    "fees",
+    "net_eur",
+    "net_pct",
 ]
 
 
@@ -797,6 +805,27 @@ with st.sidebar:
     include_shipping = st.checkbox("Calcola margine netto con spedizione", value=True)
 
     colored_header(
+        label="🧮 Cost Model",
+        description="Parametri di costo",
+        color_name="blue-70",
+    )
+    sale_price_source = st.selectbox(
+        "Prezzo di vendita",
+        ["bb_now", "new_now", "amz_now"],
+        index=0,
+    )
+    apply_coupon = st.checkbox("Applica coupon", value=False)
+    apply_biz_discount = st.checkbox("Applica sconto business", value=False)
+    fulfillment = st.selectbox("Fulfillment", ["FBA", "FBM"], index=0)
+    referral_pct = st.number_input("Referral %", value=15.0, step=0.1)
+    fba_fee_input = st.number_input("FBA fee manuale (€)", value=0.0, step=0.1)
+    shipping_out_per_kg = st.number_input("Spedizione uscita €/kg", value=0.0, step=0.1)
+    extra_handling_eur = st.number_input("Extra handling (€)", value=0.0, step=0.1)
+    shipping_inbound_eur = st.number_input("Spedizione inbound (€)", value=0.0, step=0.1)
+    dim_divisor = st.number_input("Divisore volumetrico", value=5000, step=1)
+    purchase_price_input = st.number_input("Costo di acquisto (€)", value=0.0, step=0.1)
+
+    colored_header(
         label="📈 Opportunity Score",
         description="Pesi e parametri",
         color_name="blue-70",
@@ -1190,6 +1219,21 @@ if avvia:
     df_merged["Volume_Score"] = 1000 / df_merged["Norm_Rank"]
     df_merged["ROI_Factor"] = df_merged["Margine_Netto"] / df_merged["Acquisto_Netto"]
 
+    cost_cfg = {
+        "sale_price_source": sale_price_source,
+        "apply_coupon": apply_coupon,
+        "apply_biz_discount": apply_biz_discount,
+        "fulfillment": fulfillment,
+        "extra_handling_eur": extra_handling_eur,
+        "shipping_inbound_eur": shipping_inbound_eur,
+        "dim_divisor": dim_divisor,
+        "shipping_out_per_kg": shipping_out_per_kg,
+        "referral_pct": referral_pct,
+        "fba_fee": fba_fee_input,
+        "purchase_price": purchase_price_input,
+    }
+    df_merged = compute_costs(df_merged, cost_cfg)
+
     weights = {
         "margin": epsilon + theta,
         "demand": beta + gamma,
@@ -1250,6 +1294,13 @@ if avvia:
         "Opportunity_Score",
         "Volume_Score",
         "Weight_kg",
+        "sale_price_used",
+        "referral_pct",
+        "fba_fee",
+        "billable_kg",
+        "fees",
+        "net_eur",
+        "net_pct",
     ]
     for col in cols_to_round:
         if col in df_finale.columns:

--- a/costs.py
+++ b/costs.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict
+
+import pandas as pd
+
+from schema import parse_eu_price, parse_percent
+
+
+PRICE_SOURCES = {
+    "bb_now": "bb_now",
+    "new_now": "new_now",
+    "amz_now": "amz_now",
+}
+
+
+def _pick_price(row: pd.Series, source: str) -> float:
+    col = PRICE_SOURCES.get(source, "bb_now")
+    return parse_eu_price(row.get(col))
+
+
+def _safe_number(x: Any) -> float:
+    if x is None:
+        return math.nan
+    try:
+        return float(x)
+    except Exception:
+        return parse_eu_price(x)
+
+
+def compute_row_costs(row: pd.Series, cfg: Dict[str, Any]) -> Dict[str, float]:
+    sale_price = _pick_price(row, cfg.get("sale_price_source", "bb_now"))
+    if cfg.get("apply_coupon"):
+        cp = parse_percent(row.get("coupon_pct"))
+        if math.isfinite(cp) and cp > 0:
+            sale_price *= 1.0 - cp / 100.0
+        ca = parse_eu_price(row.get("coupon_abs"))
+        if math.isfinite(ca) and ca > 0:
+            sale_price -= ca
+    if cfg.get("apply_biz_discount"):
+        bp = parse_percent(row.get("biz_discount_pct"))
+        if math.isfinite(bp) and bp > 0:
+            sale_price *= 1.0 - bp / 100.0
+
+    referral_pct = cfg.get("referral_pct", 15.0)
+    rp = parse_percent(row.get("referral_fee_pct"))
+    if math.isfinite(rp) and rp > 0:
+        referral_pct = rp
+
+    fba_fee = 0.0
+    if cfg.get("fulfillment", "FBA") == "FBA":
+        f = parse_eu_price(row.get("fba_pickpack_fee"))
+        if math.isfinite(f) and f > 0:
+            fba_fee = f
+        else:
+            fba_fee = cfg.get("fba_fee", 0.0)
+
+    weight_kg = _safe_number(row.get("weight_kg"))
+    volume_cm3 = _safe_number(row.get("volume_cm3"))
+    volumetric_kg = (
+        volume_cm3 / cfg.get("dim_divisor", 5000)
+        if math.isfinite(volume_cm3)
+        else math.nan
+    )
+    billable_kg = math.nan
+    if math.isfinite(weight_kg) and math.isfinite(volumetric_kg):
+        billable_kg = max(weight_kg, volumetric_kg)
+    elif math.isfinite(weight_kg):
+        billable_kg = weight_kg
+    elif math.isfinite(volumetric_kg):
+        billable_kg = volumetric_kg
+
+    shipping_out_eur = (
+        cfg.get("shipping_out_per_kg", 0.0) * billable_kg
+        if math.isfinite(billable_kg)
+        else 0.0
+    )
+
+    gross_revenue = sale_price
+    fees = gross_revenue * (referral_pct / 100.0)
+    if cfg.get("fulfillment", "FBA") == "FBA":
+        fees += fba_fee
+
+    cost_basis = _safe_number(
+        row.get("purchase_price")
+        or row.get("Acquisto_Netto")
+        or cfg.get("purchase_price")
+    )
+    if not math.isfinite(cost_basis):
+        cost_basis = 0.0
+
+    other_costs = (
+        cfg.get("extra_handling_eur", 0.0)
+        + cfg.get("shipping_inbound_eur", 0.0)
+        + shipping_out_eur
+    )
+
+    net_eur = gross_revenue - fees - cost_basis - other_costs
+    net_pct = (100.0 * net_eur / cost_basis) if cost_basis > 0 else math.nan
+
+    return {
+        "sale_price_used": sale_price,
+        "referral_pct": referral_pct,
+        "fba_fee": fba_fee,
+        "billable_kg": billable_kg,
+        "fees": fees,
+        "net_eur": net_eur,
+        "net_pct": net_pct,
+    }
+
+
+def compute_costs(df: pd.DataFrame, cfg: Dict[str, Any]) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+    add = df.apply(lambda r: pd.Series(compute_row_costs(r, cfg)), axis=1)
+    return pd.concat([df, add], axis=1)
+

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+
+from costs import compute_costs
+
+
+def test_basic_cost_model():
+    df = pd.DataFrame(
+        {
+            "bb_now": ["10,00 €"],
+            "coupon_abs": ["1,00 €"],
+            "coupon_pct": ["10%"],
+            "biz_discount_pct": ["5%"],
+            "referral_fee_pct": ["8%"],
+            "fba_pickpack_fee": ["2,00 €"],
+            "weight_kg": [1.0],
+            "volume_cm3": [6000],
+            "purchase_price": [5.0],
+        }
+    )
+    cfg = {
+        "sale_price_source": "bb_now",
+        "apply_coupon": True,
+        "apply_biz_discount": True,
+        "fulfillment": "FBA",
+        "extra_handling_eur": 1.0,
+        "shipping_inbound_eur": 0.5,
+        "dim_divisor": 5000,
+        "shipping_out_per_kg": 1.0,
+        "referral_pct": 15.0,
+        "fba_fee": 1.0,
+        "purchase_price": 5.0,
+    }
+    out = compute_costs(df, cfg)
+    row = out.iloc[0]
+    assert abs(row["sale_price_used"] - 7.6) < 1e-6
+    assert abs(row["fees"] - 2.608) < 1e-6
+    assert abs(row["billable_kg"] - 1.2) < 1e-6
+    assert abs(row["net_eur"] + 2.708) < 1e-6
+    assert abs(row["net_pct"] + 54.16) < 0.01
+    assert row["referral_pct"] == 8.0
+    assert row["fba_fee"] == 2.0
+


### PR DESCRIPTION
## Summary
- add standalone `costs.py` for calculating sale price, fees, and net margins
- expose a "Cost Model" section in the sidebar with configurable pricing and cost inputs
- compute and display net profit metrics, including shipping weight handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898cf7de3d08320b69b26e45e4d8ad7