### PR TITLE
Add interpretable scoring v2 with penalties

### DIFF
--- a/score.py
+++ b/score.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import math
 import re
 from typing import Any, Dict
 
+import numpy as np
 import pandas as pd
 import streamlit as st
 
@@ -138,3 +140,134 @@ def aggregate_opportunities(df: pd.DataFrame) -> pd.DataFrame:
     cols += ["Best_Market", "Opportunity_Score"]
 
     return best[cols].sort_values("Opportunity_Score", ascending=False).reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+#  New interpretable scoring utilities
+# ---------------------------------------------------------------------------
+
+
+def sigmoid(series: pd.Series, mid: float, k: float) -> pd.Series:
+    """Standard logistic sigmoid centred around ``mid``.
+
+    Parameters
+    ----------
+    series:
+        Input values.
+    mid:
+        Midpoint (value yielding 0.5).
+    k:
+        Steepness of the curve.
+    """
+
+    s = pd.to_numeric(series, errors="coerce").fillna(0.0)
+    return 1.0 / (1.0 + np.exp(-k * (s - mid)))
+
+
+def minmax(series: pd.Series, cap_p95: bool = False) -> pd.Series:
+    """Scale a series between 0 and 1.
+
+    If ``cap_p95`` is True the upper range is capped at the 95th percentile
+    before scaling which reduces the impact of strong outliers.
+    """
+
+    s = pd.to_numeric(series, errors="coerce")
+    if cap_p95 and not s.dropna().empty:
+        cap = s.quantile(0.95)
+        s = s.clip(upper=cap)
+    min_val = s.min()
+    max_val = s.max()
+    if not np.isfinite(min_val) or not np.isfinite(max_val) or max_val == min_val:
+        return pd.Series(0.0, index=series.index)
+    return (s - min_val) / (max_val - min_val)
+
+
+def pct_rank(series: pd.Series) -> pd.Series:
+    """Return the percentage rank of each element.
+
+    Values are ranked using ``method='max'`` so that the best value receives 1.0
+    and the worst 0.0.
+    """
+
+    s = pd.to_numeric(series, errors="coerce")
+    if s.dropna().empty:
+        return pd.Series(0.0, index=series.index)
+    return s.rank(pct=True, method="max")
+
+
+def compute_score_v2(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute interpretable, robust score for each row in ``df``.
+
+    The function adds ``score_v2`` (0-100 scale), ``score_class`` and
+    ``score_explain`` columns to the returned frame.
+    """
+
+    if df is None or df.empty:
+        return df
+
+    out = df.copy()
+
+    # --- base features -------------------------------------------------
+    out["s_margin_pct"] = sigmoid(out.get("net_pct", 0), mid=15, k=0.25)
+    out["s_margin_eur"] = minmax(out.get("net_eur", 0).clip(lower=0), cap_p95=True)
+    out["s_speed"] = sigmoid(np.log1p(out.get("bought_30d", 0)), mid=np.log(30), k=1)
+    out["s_rank"] = 1.0 - pct_rank(out.get("rank_now", 0))
+    offers_comp = pd.to_numeric(out.get("offer_new_now", 0), errors="coerce").fillna(0)
+    out["offers_competition_norm"] = (offers_comp / 50.0).clip(0.0, 1.0)
+
+    # --- penalties -----------------------------------------------------
+    bb_now = pd.to_numeric(out.get("bb_now", 0), errors="coerce")
+    bb_90d = pd.to_numeric(out.get("bb_90d", np.nan), errors="coerce")
+    bb_std_30d = pd.to_numeric(out.get("bb_std_30d", 0), errors="coerce")
+
+    delta = pd.Series(0.0, index=out.index)
+    mask = bb_90d.notna() & (bb_90d != 0)
+    delta[mask] = (bb_now[mask] - bb_90d[mask]).abs() / bb_90d[mask]
+    # precision bonus: higher std => higher penalty (relative to current price)
+    std_factor = pd.Series(0.0, index=out.index)
+    good = mask & bb_now.notna() & (bb_now != 0)
+    std_factor[good] = bb_std_30d[good].fillna(0) / bb_now[good]
+    out["p_volatility"] = (delta + std_factor).clip(0.0, 0.5)
+
+    out["p_competition"] = (offers_comp / 50.0).clip(0.0, 0.4)
+    amz_dom = out.get("amz_dominant", False)
+    out["p_amz_dom"] = pd.Series(amz_dom).fillna(False).astype(float).apply(lambda x: 0.15 if x else 0.0)
+
+    # --- final score ---------------------------------------------------
+    raw = (
+        0.35 * out["s_margin_pct"]
+        + 0.20 * out["s_margin_eur"]
+        + 0.25 * out["s_speed"]
+        + 0.15 * out["s_rank"]
+        + 0.05 * (1 - out["offers_competition_norm"])
+    )
+
+    out["score_v2"] = 100 * (
+        raw - out["p_volatility"] - out["p_competition"] - out["p_amz_dom"]
+    )
+
+    def _classify(x: float) -> str:
+        if x >= 75:
+            return "A"
+        if x >= 55:
+            return "B"
+        return "C"
+
+    out["score_class"] = out["score_v2"].apply(_classify)
+
+    def _explain(row: pd.Series) -> str:
+        data = {
+            "margin_pct": round(0.35 * row["s_margin_pct"], 3),
+            "margin_eur": round(0.20 * row["s_margin_eur"], 3),
+            "speed": round(0.25 * row["s_speed"], 3),
+            "rank": round(0.15 * row["s_rank"], 3),
+            "volatility_pen": round(row["p_volatility"], 3),
+            "competition_pen": round(row["p_competition"], 3),
+            "amz_dom_pen": round(row["p_amz_dom"], 3),
+        }
+        return json.dumps(data, ensure_ascii=False)
+
+    out["score_explain"] = out.apply(_explain, axis=1)
+
+    return out
+

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -12,6 +12,7 @@ from score import (
     volatility_score,
     risk_score,
     aggregate_opportunities,
+    compute_score_v2,
 )
 
 
@@ -46,3 +47,23 @@ def test_aggregate_opportunities():
     a1 = agg[agg["ASIN"] == "A1"].iloc[0]
     assert a1["Opportunity_Score"] == 20
     assert a1["Best_Market"] == "FR"
+
+
+def test_compute_score_v2_basic():
+    df = pd.DataFrame(
+        {
+            "net_pct": [20, 10],
+            "net_eur": [5, 1],
+            "bought_30d": [50, 5],
+            "rank_now": [1000, 50000],
+            "offer_new_now": [10, 80],
+            "bb_now": [10, 15],
+            "bb_90d": [9, 15],
+            "bb_std_30d": [0.5, 2.0],
+            "amz_dominant": [False, True],
+        }
+    )
+    res = compute_score_v2(df)
+    assert "score_v2" in res.columns
+    assert "score_class" in res.columns
+    assert ((res["score_v2"].notna()) & (res["score_v2"].abs() <= 1000)).all()


### PR DESCRIPTION
## Summary
- implement sigmoid/minmax utilities and a new compute_score_v2 scoring pipeline
- factor in volatility, competition and Amazon dominance penalties
- add basic tests for the new scoring function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d8ba26cc8320bb403114ea51b319