### PR TITLE
Ensure stable parsing and scoring with added tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -378,6 +378,37 @@ def compute_historic_deals(df: pd.DataFrame) -> pd.DataFrame:
 
     return work
 
+
+@st.cache_data(ttl=180)
+def filter_view(
+    df: pd.DataFrame,
+    params_model: Dict[str, Any],
+    params_filters: Dict[str, Any],
+) -> pd.DataFrame:
+    """Return ``df`` filtered according to ``params_filters``.
+
+    The cache key includes ``params_model`` and ``params_filters`` to ensure
+    views are invalidated when either changes.
+    """
+
+    work = df.copy()
+
+    if not params_filters.get("include_refurbished", True) and "condition" in work.columns:
+        work = work[work["condition"] != "refurbished/ricondizionato"]
+    if params_filters.get("prime_bb_only", False) and "prime_bb" in work.columns:
+        work = work[work["prime_bb"]]
+    if "return_rate_pct" in work.columns:
+        rr = pd.to_numeric(work["return_rate_pct"], errors="coerce").fillna(0)
+        max_rr = params_filters.get("max_return_rate_pct", float("inf"))
+        work = work[rr <= max_rr]
+    if params_filters.get("exclude_amz_dom", False) and "amz_dominant" in work.columns:
+        work = work[~work["amz_dominant"]]
+    max_offers = params_filters.get("max_new_offers")
+    if max_offers is not None and "offer_new_now" in work.columns:
+        work = work[work["offer_new_now"].fillna(0) <= max_offers]
+
+    return work
+
 def render_results(
     df_finale: pd.DataFrame,
     df_ranked: pd.DataFrame,
@@ -389,18 +420,15 @@ def render_results(
     max_return_rate_pct: float,
 ) -> None:
     """Render the dashboard and detailed results grids."""
-    work = df_finale.copy()
-    if not include_refurbished and "condition" in work.columns:
-        work = work[work["condition"] != "refurbished/ricondizionato"]
-    if prime_bb_only and "prime_bb" in work.columns:
-        work = work[work["prime_bb"]]
-    if "return_rate_pct" in work.columns:
-        rr = pd.to_numeric(work["return_rate_pct"], errors="coerce").fillna(0)
-        work = work[rr <= max_return_rate_pct]
-    if exclude_amz_dom and "amz_dominant" in work.columns:
-        work = work[~work["amz_dominant"]]
-    if "offer_new_now" in work.columns:
-        work = work[work["offer_new_now"].fillna(0) <= max_new_offers]
+    params_model = st.session_state.get("params_model", {})
+    params_filters = {
+        "include_refurbished": include_refurbished,
+        "prime_bb_only": prime_bb_only,
+        "max_return_rate_pct": max_return_rate_pct,
+        "exclude_amz_dom": exclude_amz_dom,
+        "max_new_offers": max_new_offers,
+    }
+    work = filter_view(df_finale, params_model, params_filters)
     df_ranked = aggregate_opportunities(work)
 
     triaging_raw = best_cross_market_combo(

--- a/tests/test_best_combo.py
+++ b/tests/test_best_combo.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from analysis import best_cross_market_combo
+
+
+def test_single_locale_degrades_gracefully():
+    df = pd.DataFrame(
+        {
+            "asin": ["A1"],
+            "title": ["Prod"],
+            "locale": ["IT"],
+            "sale_price": [30.0],
+            "purchase_price": [10.0],
+            "rank_now": [100.0],
+            "bought_30d": [50.0],
+            "offer_new_now": [5.0],
+            "score_v2": [80.0],
+        }
+    )
+    result = best_cross_market_combo(df, sell_targets=["IT"])
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row["best_buy_locale"] == "IT"
+    assert row["best_sell_locale"] == "IT"
+    assert row["net_eur"] == 20.0
+    assert row["net_pct"] == 200.0
+

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from schema import (
+    parse_eu_price,
+    parse_percent,
+    parse_bool,
+    validate_and_standardize,
+)
+
+
+def test_parse_eu_price():
+    assert parse_eu_price("1.000,00 €") == 1000.0
+
+
+def test_parse_percent():
+    assert parse_percent("7,00 %") == 7.0
+
+
+def test_parse_bool_yes_no():
+    assert parse_bool("yes") is True
+    assert parse_bool("no") is False
+
+
+def test_validate_and_standardize_emoji_header():
+    df = pd.DataFrame({"Buy Box 🚚 : current": ["1.000,00 €"]})
+    out = validate_and_standardize(df)
+    assert "bb_now" in out.columns
+    assert out.loc[0, "bb_now"] == 1000.0
+

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from score import compute_score_v2
+
+
+def _base_df():
+    return pd.DataFrame(
+        {
+            "net_pct": [20.0],
+            "net_eur": [10.0],
+            "bought_30d": [100.0],
+            "rank_now": [1000.0],
+            "offer_new_now": [5.0],
+            "bb_now": [100.0],
+            "bb_90d": [100.0],
+            "bb_std_30d": [0.0],
+            "amz_dominant": [False],
+        }
+    )
+
+
+def test_score_decreases_with_more_offers():
+    base = compute_score_v2(_base_df())
+    more_offers = _base_df()
+    more_offers["offer_new_now"] *= 2
+    res = compute_score_v2(more_offers)
+    assert res.loc[0, "score_v2"] < base.loc[0, "score_v2"]
+
+
+def test_buybox_divergence_increases_penalty():
+    base = compute_score_v2(_base_df())
+    deviated = _base_df()
+    deviated["bb_now"] = 200.0
+    res = compute_score_v2(deviated)
+    assert res.loc[0, "p_volatility"] > base.loc[0, "p_volatility"]
+    assert res.loc[0, "score_v2"] < base.loc[0, "score_v2"]
+


### PR DESCRIPTION
## Summary
- cache filtered views with `st.cache_data(ttl=180)` using model and filter params as key
- add schema tests for EU price/percent parsing, boolean handling, and emoji headers
- add score tests for offer competition and buy box divergence effects
- add best combo test validating single-locale fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689917b1473083208b22f545e6046c94