### PR TITLE
Handle VAT rates given in decimal or percent for net sale

### DIFF
--- a/app.py
+++ b/app.py
@@ -225,6 +225,14 @@ def get_vat_for_locale(locale_raw: str) -> float:
         return 0.22
 
 
+def _vat_to_decimal(v):
+    # accetta sia 0.22 che 22
+    if v is None or not np.isfinite(float(v)):
+        return 0.22
+    v = float(v)
+    return v if v < 1.0 else v / 100.0
+
+
 def score_to_class(score: float) -> str:
     """Map opportunity score to class A/B/C."""
     label = classify_opportunity(score)[0]
@@ -1439,7 +1447,10 @@ if avvia:
     df_merged["Vendita_Netto"] = df_merged.apply(
         lambda row: row["Price_Comp"]
         / (
-            1 + VAT_RATES.get(normalize_locale(row.get("Locale (comp)", "")), 0) / 100.0
+            1.0
+            + _vat_to_decimal(
+                VAT_RATES.get(normalize_locale(row.get("Locale (comp)", "")), 0.22)
+            )
         ),
         axis=1,
     )


### PR DESCRIPTION
## Summary
- add `_vat_to_decimal` helper that normalizes VAT values expressed as either decimals or percentages
- use the helper when computing `Vendita_Netto` to divide by `1 + VAT` in decimal form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689999642cf88320b7239f272b69949b