### PR TITLE
feat: add core modules and canonical column parsing

### DIFF
--- a/core/columns.py
+++ b/core/columns.py
@@ -1,0 +1,190 @@
+"""Column utilities and canonical mapping for datasets."""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime
+from typing import Any, Dict
+
+import pandas as pd
+
+# Mapping from raw dataset headers (regex) to canonical snake_case names
+CANONICAL_MAP: Dict[str, str] = {
+    r"^Locale$": "locale",
+    r"^Title$": "title",
+    r"^ASIN$": "asin",
+    r"^Parent ASIN$": "parent_asin",
+    r"^Brand$": "brand",
+    r"^Categories: Root$": "category_root",
+    r"^Categories: Sub$": "category_sub",
+    r"^Sales Rank: Current$": "rank_cur",
+    r"^Sales Rank: 30 days avg\.": "rank_avg_30",
+    r"^Sales Rank: 90 days avg\.": "rank_avg_90",
+    r"^Sales Rank: 180 days avg\.": "rank_avg_180",
+    r"^Sales Rank: 365 days avg\.": "rank_avg_365",
+    r"^Sales Rank: 30 days drop %$": "rank_drop_pct_30",
+    r"^Sales Rank: 90 days drop %$": "rank_drop_pct_90",
+    r"^Sales Rank: Drops last 30 days$": "rank_drops_30",
+    r"^Sales Rank: Drops last 90 days$": "rank_drops_90",
+    r"^Bought in past month$": "bought_month",
+    r"^90 days change % monthly sold$": "sold_change_pct_90",
+    r"^Return Rate$": "return_rate",
+    r"^Reviews: Rating$": "rating_value",
+    r"^Reviews: Rating Count$": "rating_count",
+    r"^Reviews: Rating Count - 30 days avg\.": "rating_count_avg_30",
+    r"^Reviews: Rating Count - 90 days avg\.": "rating_count_avg_90",
+    r"^Last Price Change$": "last_price_change",
+    r"^Last Update$": "last_update",
+    r"^Buy Box .*: Current$": "bb_now",
+    r"^Buy Box .*: 30 days avg\.": "bb_avg_30",
+    r"^Buy Box .*: 90 days avg\.": "bb_avg_90",
+    r"^Buy Box .*: 180 days avg\.": "bb_avg_180",
+    r"^Buy Box .*: 365 days avg\.": "bb_avg_365",
+    r"^Buy Box .*: 30 days drop %$": "bb_drop_pct_30",
+    r"^Buy Box .*: Is Lowest$": "bb_is_lowest",
+    r"^Buy Box .*: Lowest$": "bb_lowest",
+    r"^Buy Box .*: Highest$": "bb_highest",
+    r"^Buy Box .*: 90 days OOS$": "bb_oos_pct_90",
+    r"^Buy Box: % Amazon 30 days$": "bb_amz_pct_30",
+    r"^Buy Box: % Amazon 90 days$": "bb_amz_pct_90",
+    r"^Buy Box: % Amazon 180 days$": "bb_amz_pct_180",
+    r"^Buy Box: % Amazon 365 days$": "bb_amz_pct_365",
+    r"^Buy Box: Winner Count 30 days$": "bb_winner_count_30",
+    r"^Buy Box: Winner Count 90 days$": "bb_winner_count_90",
+    r"^Buy Box: Standard Deviation 30 days$": "bb_std_30",
+    r"^Buy Box: Standard Deviation 90 days$": "bb_std_90",
+    r"^Buy Box: Standard Deviation 365 days$": "bb_std_365",
+    r"^Buy Box: Flipability 30 days$": "bb_flip_30",
+    r"^Buy Box: Flipability 90 days$": "bb_flip_90",
+    r"^Buy Box: Flipability 365 days$": "bb_flip_365",
+    r"^Buy Box: Unqualified$": "bb_unqualified",
+    r"^Competitive Price Threshold$": "competitive_threshold",
+    r"^Suggested Lower Price$": "suggested_lower",
+    r"^Amazon: Current$": "amazon_now",
+    r"^Amazon: 90 days OOS$": "amazon_oos_pct_90",
+    r"^Amazon: OOS Count 30 days$": "amazon_oos_count_30",
+    r"^Amazon: OOS Count 90 days$": "amazon_oos_count_90",
+    r"^Amazon: Availability of the Amazon offer$": "amazon_availability",
+    r"^Amazon: Amazon offer shipping delay$": "amazon_ship_delay",
+    r"^New: Current$": "new_now",
+    r"^New Offer Count: Current$": "new_offer_count_now",
+    r"^New Offer Count: 30 days avg\.": "new_offer_count_avg_30",
+    r"^Total Offer Count$": "total_offer_count",
+    r"^One Time Coupon: Absolute$": "coupon_abs",
+    r"^One Time Coupon: Percentage$": "coupon_pct",
+    r"^Business Discount: Percentage$": "business_disc_pct",
+    r"^New, 3rd Party FBA: Current$": "fba_3p_now",
+    r"^New, 3rd Party FBM .*: Current$": "fbm_3p_now",
+    r"^FBA Pick&Pack Fee$": "fba_pickpack_fee",
+    r"^Referral Fee %$": "referral_fee_pct",
+    r"^Referral Fee based on current Buy Box price$": "referral_fee_amount",
+    r"^MAP restriction$": "map_restriction",
+    r"^URL: Amazon$": "url_amazon",
+    r"^URL: Keepa$": "url_keepa",
+    r"^Package: Dimension \(cm³\)$": "pkg_cm3",
+    r"^Package: Length \(cm\)$": "pkg_len_cm",
+    r"^Package: Width \(cm\)$": "pkg_w_cm",
+    r"^Package: Height \(cm\)$": "pkg_h_cm",
+    r"^Package: Weight \(g\)$": "pkg_weight_g",
+    r"^Item: Weight \(g\)$": "item_weight_g",
+    r"^Prime Eligible \(Buy Box\)$": "prime_eligible_bb",
+}
+
+
+def normalize_header(header: str) -> str:
+    """Return ``header`` with extra spaces and emojis removed."""
+    if not isinstance(header, str):
+        return ""
+    # remove common emojis or non word characters except basic punctuation
+    header = header.replace("🚚", " ")
+    header = re.sub(r"[\u2600-\u26FF\u2700-\u27BF\U0001F300-\U0001F6FF\U0001F900-\U0001F9FF]+", "", header)
+    # normalise whitespace and colons
+    header = re.sub(r"\s*:\s*", ": ", header)
+    header = re.sub(r"\s+", " ", header)
+    return header.strip()
+
+
+def parse_euro(value: Any) -> float:
+    """Parse euro-formatted strings to ``float``.
+
+    Handles thousand separators, euro symbols and decimal commas.
+    Returns ``math.nan`` when parsing fails.
+    """
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return math.nan
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return math.nan
+    cleaned = value.replace("€", "").replace(".", "").replace(",", ".")
+    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    try:
+        return float(cleaned)
+    except Exception:
+        return math.nan
+
+
+def parse_pct(value: Any) -> float:
+    """Parse percentage strings into a fraction (0-1)."""
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return math.nan
+    if isinstance(value, (int, float)):
+        v = float(value)
+        return v / 100 if abs(v) > 1 else v
+    if not isinstance(value, str):
+        return math.nan
+    cleaned = value.replace("%", "").replace(",", ".")
+    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    if not cleaned:
+        return math.nan
+    try:
+        v = float(cleaned)
+        return v / 100 if abs(v) > 1 else v
+    except Exception:
+        return math.nan
+
+
+def parse_bool(value: Any) -> bool:
+    """Parse common textual representations of booleans."""
+    if isinstance(value, bool):
+        return value
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return False
+    if not isinstance(value, str):
+        return False
+    s = value.strip().lower()
+    if s in {"yes", "true", "1", "y", "t"}:
+        return True
+    if s in {"no", "false", "0", "n", "f", "no amazon offer exists"}:
+        return False
+    return False
+
+
+def parse_dt(value: Any) -> pd.Timestamp:
+    """Parse a datetime value into ``pd.Timestamp``.
+
+    Accepts ``datetime`` objects, pandas ``Timestamp`` or strings in
+    ``YYYY-MM-DD HH:MM`` format. Returns ``pd.NaT`` on failure.
+    """
+    if isinstance(value, pd.Timestamp):
+        return value
+    if isinstance(value, datetime):
+        return pd.Timestamp(value)
+    if not isinstance(value, str):
+        return pd.NaT
+    return pd.to_datetime(value, errors="coerce")
+
+
+def apply_canonical(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with columns renamed to their canonical names."""
+    rename_map = {}
+    for col in df.columns:
+        norm = normalize_header(col)
+        for pattern, canonical in CANONICAL_MAP.items():
+            if re.match(pattern, norm, flags=re.IGNORECASE):
+                rename_map[col] = canonical
+                break
+    if rename_map:
+        df = df.rename(columns=rename_map)
+    return df

--- a/core/filters.py
+++ b/core/filters.py
@@ -1,0 +1,31 @@
+"""Filtering utilities for Deal Radar and Value Radar."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+
+def deal_radar(df: pd.DataFrame, min_flip: float = 0.0) -> pd.DataFrame:
+    """Return rows matching hard gating for Deal Radar.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame.
+    min_flip:
+        Minimum flipability score required to pass the filter.
+    """
+    mask = df.get("bb_flip_30", pd.Series(0, index=df.index)) > min_flip
+    return df[mask].copy()
+
+
+def value_radar(
+    df: pd.DataFrame, min_margin: float = 0.0, max_rank: Optional[float] = None
+) -> pd.DataFrame:
+    """Return rows passing Value Radar hard gates."""
+    mask = df.get("margin", pd.Series(0, index=df.index)) > min_margin
+    if max_rank is not None:
+        mask &= df.get("rank_cur", pd.Series(float("inf"), index=df.index)) < max_rank
+    return df[mask].copy()

--- a/core/profit.py
+++ b/core/profit.py
@@ -1,0 +1,41 @@
+"""Helpers for computing profit and cost structures."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from .columns import parse_euro
+
+
+def fbm_profit(price: float, cost: float, shipping: float = 0.0) -> float:
+    """Compute profit for a Fulfilled By Merchant (FBM) item."""
+    return float(price) - float(cost) - float(shipping)
+
+
+def fba_profit(price: float, cost: float, fees: float = 0.0) -> float:
+    """Placeholder for Fulfilled By Amazon (FBA) profit calculation."""
+    return float(price) - float(cost) - float(fees)
+
+
+def compute_profit(row: Dict[str, Any], method: str = "FBM") -> float:
+    """Compute profit for ``row`` using ``method``.
+
+    ``row`` is expected to contain at least ``bb_now`` and ``cost`` columns.
+    ``method`` can be ``FBM`` (default) or ``FBA``.
+    """
+    price = parse_euro(row.get("bb_now"))
+    cost = parse_euro(row.get("cost", 0))
+    shipping = parse_euro(row.get("shipping", 0))
+    fees = parse_euro(row.get("fba_pickpack_fee", 0)) + parse_euro(
+        row.get("referral_fee_amount", 0)
+    )
+    if method.upper() == "FBA":
+        return fba_profit(price, cost, fees)
+    return fbm_profit(price, cost, shipping)
+
+
+def profit_series(df: pd.DataFrame, method: str = "FBM") -> pd.Series:
+    """Return a series with profit for each row in ``df``."""
+    return df.apply(lambda r: compute_profit(r, method=method), axis=1)

--- a/core/score_v2.py
+++ b/core/score_v2.py
@@ -1,0 +1,37 @@
+"""Second generation scoring model with granular sub-scores."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+SUBSCORES = ["P", "L", "E", "C", "A", "Q", "X"]
+
+def _scale(series: pd.Series) -> pd.Series:
+    """Normalize ``series`` to a 0-100 range."""
+    min_val = series.min()
+    max_val = series.max()
+    if pd.isna(min_val) or pd.isna(max_val) or max_val == min_val:
+        return pd.Series(0.0, index=series.index)
+    return (series - min_val) / (max_val - min_val) * 100
+
+def compute_subscores(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute placeholder P/L/E/C/A/Q/X subscores."""
+    df = df.copy()
+    df["P"] = _scale(df.get("profit", pd.Series(0, index=df.index)))
+    df["L"] = _scale(df.get("liquidity", pd.Series(0, index=df.index)))
+    df["E"] = _scale(df.get("efficiency", pd.Series(0, index=df.index)))
+    df["C"] = _scale(df.get("competition", pd.Series(0, index=df.index)))
+    df["A"] = _scale(df.get("availability", pd.Series(0, index=df.index)))
+    df["Q"] = _scale(df.get("quality", pd.Series(0, index=df.index)))
+    df["X"] = _scale(df.get("extra", pd.Series(0, index=df.index)))
+    return df
+
+def combine_opportunity(df: pd.DataFrame, weights: Dict[str, float] | None = None) -> pd.DataFrame:
+    """Combine subscores into a single Opp2 score."""
+    df = compute_subscores(df)
+    weights = weights or {k: 1.0 for k in SUBSCORES}
+    score = sum(df[k] * weights.get(k, 1.0) for k in SUBSCORES)
+    df["Opp2"] = score / sum(weights.get(k, 1.0) for k in SUBSCORES)
+    return df

--- a/core/signals.py
+++ b/core/signals.py
@@ -1,0 +1,59 @@
+"""Derived signal calculations used within the analyzer."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import pandas as pd
+
+
+def z_score(series: pd.Series) -> pd.Series:
+    """Return the z-score for ``series`` ignoring ``NaN`` values."""
+    mean = series.mean()
+    std = series.std(ddof=0)
+    if std == 0 or math.isnan(std):
+        return pd.Series(0.0, index=series.index)
+    return (series - mean) / std
+
+
+def delta_pct(current: pd.Series, previous: pd.Series) -> pd.Series:
+    """Return the percentage change between ``current`` and ``previous``."""
+    return (current - previous) / previous.replace(0, pd.NA)
+
+
+def review_momentum(df: pd.DataFrame) -> pd.Series:
+    """Compute review momentum from rating counts.
+
+    The metric is defined as the z-score of the difference between the
+    current rating count and the 30 day average.
+    """
+    diff = df.get("rating_count", pd.Series(dtype=float)) - df.get(
+        "rating_count_avg_30", pd.Series(dtype=float)
+    )
+    return z_score(diff.fillna(0))
+
+
+def amazon_hazard(df: pd.DataFrame) -> pd.Series:
+    """Return a simple hazard score based on Amazon's presence.
+
+    A value of ``1`` indicates Amazon is in the buy box now, ``0`` otherwise.
+    Missing data results in ``0``.
+    """
+    now = df.get("amazon_now")
+    if now is None:
+        return pd.Series(0, index=df.index)
+    return now.notna().astype(int)
+
+
+def flipability_score(df: pd.DataFrame, window: str = "30") -> pd.Series:
+    """Estimate how "flipable" an item is based on Buy Box standard deviation.
+
+    The higher the standard deviation relative to the mean, the more
+    opportunities there might be to flip.
+    """
+    std_col = f"bb_std_{window}"
+    mean_col = f"bb_avg_{window}"
+    std = df.get(std_col, pd.Series(dtype=float))
+    mean = df.get(mean_col, pd.Series(dtype=float))
+    return (std / mean.replace(0, pd.NA)).fillna(0)

--- a/loaders.py
+++ b/loaders.py
@@ -11,6 +11,14 @@ import pandas as pd
 import duckdb
 import streamlit as st
 
+from core.columns import (
+    apply_canonical,
+    parse_bool,
+    parse_dt,
+    parse_euro,
+    parse_pct,
+)
+
 
 def load_data(uploaded_file: Any) -> Optional[pd.DataFrame]:
     """Load a CSV or XLSX file into a pandas DataFrame.
@@ -32,14 +40,28 @@ def load_data(uploaded_file: Any) -> Optional[pd.DataFrame]:
             uploaded_file.seek(0)
             df = pd.read_csv(uploaded_file, sep=",", dtype=str)
     df = df.loc[:, ~df.columns.str.startswith("Unnamed")]
+    df = apply_canonical(df)
+    df = _coerce_types(df)
     return df
 
 
 @st.cache_data(show_spinner=False)
-def load_keepa(path: str | Path) -> pd.DataFrame:
-    """Load a Keepa export file from ``path``."""
+def load_keepa(path: str | Path, canonical: bool = False) -> pd.DataFrame:
+    """Load a Keepa export file from ``path``.
+
+    Parameters
+    ----------
+    path:
+        File system path to the export file.
+    canonical:
+        When ``True`` columns are normalized using :func:`apply_canonical`.
+    """
     df = pd.read_excel(path, dtype=str)
-    return df.loc[:, ~df.columns.str.contains("^Unnamed")]
+    df = df.loc[:, ~df.columns.str.contains("^Unnamed")]
+    if canonical:
+        df = apply_canonical(df)
+        df = _coerce_types(df)
+    return df
 
 
 @st.cache_data(show_spinner=False)
@@ -49,7 +71,52 @@ def load_prices(path: str | Path) -> pd.DataFrame:
         df = pd.read_excel(path, dtype=str)
     else:
         df = pd.read_csv(path, sep=";", dtype=str)
-    return df.loc[:, ~df.columns.str.contains("^Unnamed")]
+    df = df.loc[:, ~df.columns.str.contains("^Unnamed")]
+    df = apply_canonical(df)
+    return _coerce_types(df)
+
+
+def _coerce_types(df: pd.DataFrame) -> pd.DataFrame:
+    """Coerce column types based on their names."""
+    for col in df.columns:
+        name = col.lower()
+        if "%" in col or "pct" in name:
+            df[col] = df[col].apply(parse_pct)
+            continue
+        if "€" in col or any(
+            kw in name
+            for kw in [
+                "price",
+                "fee",
+                "amount",
+                "threshold",
+                "coupon",
+                "discount",
+                "now",
+                "avg",
+                "highest",
+                "lowest",
+                "cost",
+            ]
+        ):
+            df[col] = df[col].apply(parse_euro)
+            continue
+        if any(
+            kw in name
+            for kw in [
+                "is_",
+                "eligible",
+                "availability",
+                "unqualified",
+                "map_restriction",
+                "prime",
+            ]
+        ):
+            df[col] = df[col].apply(parse_bool)
+            continue
+        if any(kw in name for kw in ["date", "time", "update", "change", "last"]):
+            df[col] = df[col].apply(parse_dt)
+    return df
 
 
 def merge_data(df_keepa: pd.DataFrame, df_prices: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- add core helper modules for column normalization, signals, profit, scoring and filters
- enhance loaders with canonical column mapping and type coercion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a11ac3efc8320839b7b142ec2e45f