### PR TITLE
Handle missing locale in aggregate opportunities

### DIFF
--- a/score.py
+++ b/score.py
@@ -130,7 +130,10 @@ def aggregate_opportunities(df: pd.DataFrame) -> pd.DataFrame:
 
     idx = df.groupby("ASIN") ["Opportunity_Score"].idxmax()
     best = df.loc[idx].copy()
-    best = best.rename(columns={"Locale (comp)": "Best_Market"})
+    if "Locale (comp)" in best.columns:
+        best = best.rename(columns={"Locale (comp)": "Best_Market"})
+    else:
+        best["Best_Market"] = ""
 
     cols = ["ASIN"]
     if "Title (base)" in best.columns:

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -46,3 +46,16 @@ def test_aggregate_opportunities():
     a1 = agg[agg["ASIN"] == "A1"].iloc[0]
     assert a1["Opportunity_Score"] == 20
     assert a1["Best_Market"] == "FR"
+
+
+def test_aggregate_opportunities_without_locale():
+    df = pd.DataFrame(
+        {
+            "ASIN": ["A1", "A1", "A2"],
+            "Opportunity_Score": [10, 20, 15],
+        }
+    )
+    agg = aggregate_opportunities(df)
+    assert len(agg) == 2
+    assert "Best_Market" in agg.columns
+    assert agg["Best_Market"].eq("").all()


### PR DESCRIPTION
## Summary
- Ensure `aggregate_opportunities` creates an empty `Best_Market` column when `Locale (comp)` is missing
- Add tests for aggregating opportunities without locale data

## Testing
- `pytest tests/test_scores.py::test_aggregate_opportunities tests/test_scores.py::test_aggregate_opportunities_without_locale -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a23783158832092c4a03c9e4930df