### PR TITLE
docs: require locale columns for VAT and opportunity score

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ columns listed in `DISPLAY_COLS_ORDER` are shown:
 Any additional columns present in your dataset are ignored.
 
 
+## Uso dei dati
+
+Le colonne `Locale (base)` e `Locale (comp)` sono obbligatorie per il calcolo dell'IVA e del punteggio opportunità. Assicurati che entrambi i campi siano valorizzati in ogni riga del dataset.
+
+Esempio di record completo:
+
+```
+ASIN,Title (base),Locale (base),Locale (comp),Price_Base,Price_Comp,Bought_Comp,SalesRank_Comp
+B000123456,Prodotto esempio,IT,DE,10.00,12.00,500,15000
+```
+
+
 ## VAT and Discount Logic
 
 Locale strings from the CSV files are normalized to a two letter country code (e.g. `Amazon.de` or `de-DE` become `DE`). `GB` is converted to `UK` so that the correct VAT rate is applied automatically.


### PR DESCRIPTION
## Summary
- document that `Locale (base)` and `Locale (comp)` are required to compute VAT and the opportunity score
- add a sample row showing both locale fields populated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a237c33e08320b3cfcb6a1a4d77d4