### PR TITLE
Handle missing locale columns in opportunity aggregation

### DIFF
--- a/score.py
+++ b/score.py
@@ -128,9 +128,16 @@ def aggregate_opportunities(df: pd.DataFrame) -> pd.DataFrame:
     if "Opportunity_Score" not in df.columns:
         return pd.DataFrame(columns=["ASIN", "Best_Market", "Opportunity_Score"])
 
-    idx = df.groupby("ASIN") ["Opportunity_Score"].idxmax()
+    if "Locale (base)" not in df.columns:
+        raise KeyError("Locale (base) column missing")
+
+    idx = df.groupby("ASIN")["Opportunity_Score"].idxmax()
     best = df.loc[idx].copy()
-    best = best.rename(columns={"Locale (comp)": "Best_Market"})
+
+    if "Locale (comp)" in best.columns:
+        best = best.rename(columns={"Locale (comp)": "Best_Market"})
+    else:
+        best["Best_Market"] = ""
 
     cols = ["ASIN"]
     if "Title (base)" in best.columns:

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from loaders import load_keepa
 import pandas as pd
+import pytest
 from score import (
     margin_score,
     demand_score,
@@ -39,6 +40,7 @@ def test_aggregate_opportunities():
             "ASIN": ["A1", "A1", "A2"],
             "Opportunity_Score": [10, 20, 15],
             "Locale (comp)": ["DE", "FR", "IT"],
+            "Locale (base)": ["DE", "DE", "DE"],
         }
     )
     agg = aggregate_opportunities(df)
@@ -46,3 +48,28 @@ def test_aggregate_opportunities():
     a1 = agg[agg["ASIN"] == "A1"].iloc[0]
     assert a1["Opportunity_Score"] == 20
     assert a1["Best_Market"] == "FR"
+
+
+def test_aggregate_opportunities_no_locale_comp():
+    df = pd.DataFrame(
+        {
+            "ASIN": ["A1", "A2"],
+            "Opportunity_Score": [10, 15],
+            "Locale (base)": ["DE", "DE"],
+        }
+    )
+    agg = aggregate_opportunities(df)
+    assert len(agg) == 2
+    assert "Best_Market" in agg.columns
+
+
+def test_aggregate_opportunities_missing_base_locale():
+    df = pd.DataFrame(
+        {
+            "ASIN": ["A1"],
+            "Opportunity_Score": [10],
+            "Locale (comp)": ["DE"],
+        }
+    )
+    with pytest.raises(KeyError):
+        aggregate_opportunities(df)


### PR DESCRIPTION
## Summary
- Ensure `aggregate_opportunities` requires the `Locale (base)` column and tolerates missing `Locale (comp)`
- Add tests for missing locale columns in aggregation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a237d35348320b9b1ebfa3e77da5f