### PR TITLE
Fix market normalization and clean tests

### DIFF
--- a/score.py
+++ b/score.py
@@ -139,15 +139,11 @@ def aggregate_opportunities(df: pd.DataFrame) -> pd.DataFrame:
     idx = df.groupby("ASIN")["Opportunity_Score"].idxmax()
     best = df.loc[idx].copy()
     
- # Normalizza il nome del mercato di confronto in una colonna unica
-if "Locale (comp)" in best.columns:
-    best["Best_Market"] = best["Locale (comp)"]
-elif "Locale" in best.columns:
-    best["Best_Market"] = best["Locale"]
-
- feature/opportunity-score-v2-fb
+    # Normalizza il nome del mercato di confronto in una colonna unica
     if "Locale (comp)" in best.columns:
-        best = best.rename(columns={"Locale (comp)": "Best_Market"})
+        best["Best_Market"] = best["Locale (comp)"]
+    elif "Locale" in best.columns:
+        best["Best_Market"] = best["Locale"]
     else:
         best["Best_Market"] = ""
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -49,28 +49,18 @@ def test_aggregate_opportunities():
     assert a1["Opportunity_Score"] == 20
     assert a1["Best_Market"] == "FR"
 
-
- lp2c3v-codex/add-test-for-aggregate_opportunities
 def test_aggregate_opportunities_no_locale_comp():
     df = pd.DataFrame(
         {
             "ASIN": ["A1", "A2"],
             "Opportunity_Score": [10, 15],
             "Locale (base)": ["DE", "DE"],
-=======
-def test_aggregate_opportunities_without_locale():
-    df = pd.DataFrame(
-        {
-            "ASIN": ["A1", "A1", "A2"],
-            "Opportunity_Score": [10, 20, 15],
- feature/opportunity-score-v2-fb
         }
     )
     agg = aggregate_opportunities(df)
     assert len(agg) == 2
     assert "Best_Market" in agg.columns
- lp2c3v-codex/add-test-for-aggregate_opportunities
-    assert (agg["Best_Market"] == "").all()
+    assert agg["Best_Market"].eq("").all()
 
 
 def test_aggregate_opportunities_missing_base_locale():
@@ -83,6 +73,3 @@ def test_aggregate_opportunities_missing_base_locale():
     )
     with pytest.raises(KeyError, match=r"Locale \(base\) column missing"):
         aggregate_opportunities(df)
-=======
-    assert agg["Best_Market"].eq("").all()
- feature/opportunity-score-v2-fb


### PR DESCRIPTION
## Summary
- ensure `aggregate_opportunities` normalizes market names and remove stray merge text
- clean up tests and add coverage for missing locale columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4e697ef88320a1a3d53ca352679a