### PR TITLE
Refactor aggregate opportunities return layout

### DIFF
--- a/score.py
+++ b/score.py
@@ -150,6 +150,10 @@ def aggregate_opportunities(df: pd.DataFrame) -> pd.DataFrame:
     cols = ["ASIN"]
     if "Title (base)" in best.columns:
         cols.append("Title (base)")
-    cols += ["Best_Market", "Opportunity_Score"]
+    cols.extend(["Best_Market", "Opportunity_Score"])
 
-    return best[cols].sort_values("Opportunity_Score", ascending=False).reset_index(drop=True)
+    return (
+        best[cols]
+        .sort_values("Opportunity_Score", ascending=False)
+        .reset_index(drop=True)
+    )


### PR DESCRIPTION
## Summary
- streamline column selection in `aggregate_opportunities`
- format return statement for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a60688b30832099ca36192f103f79