### PR TITLE
Add aggregate_opportunities tests for missing locale cases

### DIFF
--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -63,6 +63,17 @@ def test_aggregate_opportunities_no_locale_comp():
     assert agg["Best_Market"].eq("").all()
 
 
+def test_aggregate_opportunities_without_locale():
+    df = pd.DataFrame(
+        {
+            "ASIN": ["A1"],
+            "Opportunity_Score": [10],
+        }
+    )
+    with pytest.raises(KeyError, match=r"Locale \(base\) column missing"):
+        aggregate_opportunities(df)
+
+
 def test_aggregate_opportunities_missing_base_locale():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- expand `aggregate_opportunities` tests to cover missing locale scenarios
- ensure aggregator gracefully handles missing comparison or base locale columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a60710ab08320b07accf6ee91cfa8